### PR TITLE
Add pip install chess_ng workflow

### DIFF
--- a/.github/workflows/pip-test.yml
+++ b/.github/workflows/pip-test.yml
@@ -1,0 +1,28 @@
+name: Check pip install
+
+on:
+  workflow_run:
+    workflows: ["Upload Python Package"]
+    types: [completed]
+
+env:
+  PACKAGE_NAME: chess_ng
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install pypi package
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools
+          pip install $PACKAGE_NAME
+          python -m $PACKAGE_NAME -h


### PR DESCRIPTION
This acts as a pypi publish smoke test to make sure that package can be correctly pulled from pypi after pypi publish.